### PR TITLE
Add Claude settings with Slack message permission

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__Slack__slack_send_message"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Added a new Claude settings configuration file to explicitly define permissions for MCP (Model Context Protocol) integrations.

## Key Changes
- Created `.claude/settings.json` with permission configuration
- Added allowlist for the Slack MCP integration, specifically enabling the `slack_send_message` capability

## Implementation Details
The settings file establishes a permissions framework that allows the Claude assistant to send messages via Slack through the MCP protocol. This configuration provides explicit control over which integrations and capabilities are available, following a principle of least privilege by requiring explicit allowlisting of specific MCP functions.

https://claude.ai/code/session_01R3btxXwSHb1mCghvc15dpb