### PR TITLE
Set default permission mode to bypassPermissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "permissions": {
+    "defaultMode": "bypassPermissions",
     "allow": [
       "mcp__Slack__slack_send_message"
     ]


### PR DESCRIPTION
## Summary
Updated the permissions configuration to set the default mode to `bypassPermissions`, allowing operations to proceed without explicit permission checks by default.

## Changes
- Added `"defaultMode": "bypassPermissions"` to the permissions configuration in `.claude/settings.json`

## Details
This change modifies the default permission behavior for the Claude settings. With `bypassPermissions` as the default mode, permission checks will be bypassed unless explicitly required, while the existing allow-list for `mcp__Slack__slack_send_message` remains in place for any operations that do require explicit permission validation.

https://claude.ai/code/session_018MfDnU4XQ9vUXXh65ZCgpY